### PR TITLE
Remove the example using barrier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpools"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["jcbritobr <jcbritobr@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/jgardona/rpools"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ A minimalist rust workerpool implementation that uses channels to synchronize th
      let atx = atx.clone();
      pool.execute(move|| {
          let tx = atx.lock().unwrap();
+
+            // a long task goes here
+            // send results to channel (use it to sync the pool with the parent thread)
+
          tx.send(1).expect("channel will be there waiting for the pool");
      });
  }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,38 +28,6 @@
 //!
 //! assert_eq!(rx.iter().take(n_jobs).fold(0, |a, b| a + b), 8);
 //!```
-//!
-//! ### Sinchronized with Barrier
-//!```
-//!
-//! use std::sync::atomic::{AtomicUsize, Ordering};
-//! use std::sync::{Arc, Barrier};
-//! use rpools::pool::WorkerPool;
-//!
-//! let n_workers = 42;
-//! let n_jobs = 23;
-//! let pool = WorkerPool::new(n_workers);
-//! let an_atomic = Arc::new(AtomicUsize::new(0));
-//!
-//! assert!(n_jobs <= n_workers, "too many jobs, will deadlock");
-//!
-//! let barrier = Arc::new(Barrier::new(n_jobs + 1));
-//! for _ in 0..n_jobs {
-//!     let barrier = barrier.clone();
-//!     let an_atomic = an_atomic.clone();
-//!
-//!     pool.execute(move|| {
-//!         // do the heavy work
-//!         an_atomic.fetch_add(1, Ordering::Relaxed);
-//!
-//!         // then wait for the other threads
-//!         barrier.wait();
-//!     });
-//! }
-//!
-//! barrier.wait();
-//! assert_eq!(an_atomic.load(Ordering::SeqCst), /* n_jobs = */ 23);
-//!```
 
 // Imports and makes pool public.
 pub mod pool;


### PR DESCRIPTION
The example using barrier was removed because its bad pratice as the barrier cant synchronize the parent thread. Use channels instead.