### PR TITLE
Fix: wg.wait() blocks indefinitely if there are no jobs #4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpools"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["jcbritobr <jcbritobr@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/jgardona/rpools"


### PR DESCRIPTION
Changed the while *start for a loop, as we only needs to check the condvar and counter.